### PR TITLE
Hide explanation div if there's no explanation

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,13 @@
         result.innerHTML =  {"free": "its free!!", true: "yes", false: "no", "custom": custom, "undefined": generateFuseMessage(input.value)}[isWaste];
     }
 
+explanation.addEventListener('DOMSubtreeModified',() => {
+    if (!this.innerHTML) {
+        this.style.display = "none";
+    } else {
+        this.removeAttribute("style");
+    };
+});
 </script>
 </html>
 

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <main>
         <div class="incontainer"><strong class="thething">Is <input oninput="check()" spellcheck="false" id="input" type="text"> a waste of money?</strong></div>
         <div id="result" class="result">Try to type something!</div>
-        <div id="explanation" class="result"></div>
+        <div id="explanation" class="result" style="display: none"></div>
     </main>
 </body>
 <script>
@@ -63,10 +63,10 @@
     }
 
 explanation.addEventListener('DOMSubtreeModified',() => {
-    if (!this.innerHTML) {
-        this.style.display = "none";
+    if (!explanation.innerHTML) {
+        explanation.style.display = "none";
     } else {
-        this.removeAttribute("style");
+        explanation.removeAttribute("style");
     };
 });
 </script>


### PR DESCRIPTION
Resolves #20
Test it at https://boomerscratch.github.io/is.wasteof.money/
The explanation div is still one the page, but it gets a "display: none" CSS style, meaning it acts like it doesn't exist.